### PR TITLE
Add Flutter Android build workflow

### DIFF
--- a/.github/workflows/flutter_android.yml
+++ b/.github/workflows/flutter_android.yml
@@ -9,8 +9,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -24,7 +28,7 @@ jobs:
         run: flutter build apk --release
 
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-apk
           path: build/app/outputs/flutter-apk/app-release.apk

--- a/.github/workflows/flutter_android.yml
+++ b/.github/workflows/flutter_android.yml
@@ -1,0 +1,30 @@
+name: Flutter Android Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.24.0'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build release APK
+        run: flutter build apk --release
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-apk
+          path: build/app/outputs/flutter-apk/app-release.apk


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds a release Android APK using Flutter 3.24.0
- upload the generated APK as an artifact for pull requests and pushes to main

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3e4c1a66483329bd83c845f28572f