### PR TITLE
Add article reader app with search and JSON data

### DIFF
--- a/assets/articles.json
+++ b/assets/articles.json
@@ -1,0 +1,22 @@
+[
+  {
+    "title": "Flutter 101",
+    "description": "Learn the basics of Flutter",
+    "content": "Flutter is Google's UI toolkit for building beautiful, natively compiled applications for mobile, web, and desktop from a single codebase."
+  },
+  {
+    "title": "Dart Language",
+    "description": "Why Dart is great for mobile apps",
+    "content": "Dart is the programming language behind Flutter. It is easy to learn, has great tooling, and is optimized for building user interfaces."
+  },
+  {
+    "title": "State Management",
+    "description": "Different approaches to managing state",
+    "content": "There are many ways to manage state in Flutter, including setState, Provider, Riverpod, Bloc, and more. Choosing the right one depends on the complexity of your app."
+  },
+  {
+    "title": "Animations",
+    "description": "Bring your UIs to life",
+    "content": "Flutter provides rich support for animations through implicit and explicit animation widgets, making it easier to add delightful motion to your apps."
+  }
+]

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,23 +1,267 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 void main() {
-  runApp(const MalleeApp());
+  runApp(const ArticleApp());
 }
 
-class MalleeApp extends StatelessWidget {
-  const MalleeApp({super.key});
+class Article {
+  final String title;
+  final String description;
+  final String content;
+
+  const Article({
+    required this.title,
+    required this.description,
+    required this.content,
+  });
+
+  factory Article.fromJson(Map<String, dynamic> json) {
+    return Article(
+      title: json['title'] as String,
+      description: json['description'] as String,
+      content: json['content'] as String,
+    );
+  }
+}
+
+class ArticleRepository {
+  const ArticleRepository();
+
+  Future<List<Article>> fetchArticles() async {
+    final rawJson = await rootBundle.loadString('assets/articles.json');
+    final List<dynamic> data = jsonDecode(rawJson) as List<dynamic>;
+    return data
+        .map((dynamic item) =>
+            Article.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+}
+
+class ArticleApp extends StatelessWidget {
+  const ArticleApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Mallee',
+      title: 'Article App',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
         useMaterial3: true,
       ),
-      home: const Scaffold(
-        body: Center(
-          child: Text('Welcome to Mallee'),
+      home: const ArticleListScreen(),
+    );
+  }
+}
+
+class ArticleListScreen extends StatefulWidget {
+  const ArticleListScreen({super.key});
+
+  @override
+  State<ArticleListScreen> createState() => _ArticleListScreenState();
+}
+
+class _ArticleListScreenState extends State<ArticleListScreen> {
+  late final Future<List<Article>> _articlesFuture;
+  final ArticleRepository _repository = const ArticleRepository();
+
+  @override
+  void initState() {
+    super.initState();
+    _articlesFuture = _repository.fetchArticles();
+  }
+
+  void _openArticle(BuildContext context, Article article) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ArticleDetailScreen(article: article),
+      ),
+    );
+  }
+
+  Future<void> _startSearch(BuildContext context, List<Article> articles) async {
+    final Article? selectedArticle = await showSearch<Article?>(
+      context: context,
+      delegate: ArticleSearchDelegate(articles),
+    );
+
+    if (!mounted || selectedArticle == null) return;
+
+    _openArticle(context, selectedArticle);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Articles'),
+      ),
+      body: FutureBuilder<List<Article>>(
+        future: _articlesFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'Something went wrong while loading the articles.\n${snapshot.error}',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+
+          final articles = snapshot.data;
+
+          if (articles == null || articles.isEmpty) {
+            return const Center(child: Text('No articles available.'));
+          }
+
+          return Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: Align(
+                  alignment: Alignment.centerRight,
+                  child: FilledButton.icon(
+                    onPressed: () => _startSearch(context, articles),
+                    icon: const Icon(Icons.search),
+                    label: const Text('Search'),
+                  ),
+                ),
+              ),
+              Expanded(
+                child: ListView.separated(
+                  itemCount: articles.length,
+                  separatorBuilder: (_, __) => const Divider(height: 0),
+                  itemBuilder: (context, index) {
+                    final article = articles[index];
+                    return ListTile(
+                      title: Text(article.title),
+                      subtitle: Text(article.description),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: () => _openArticle(context, article),
+                    );
+                  },
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class ArticleSearchDelegate extends SearchDelegate<Article?> {
+  ArticleSearchDelegate(this.articles)
+      : super(searchFieldLabel: 'Search articles');
+
+  final List<Article> articles;
+
+  Iterable<Article> _filter(String query) {
+    return articles.where(
+      (article) => article.title.toLowerCase().contains(query.toLowerCase()),
+    );
+  }
+
+  @override
+  Widget buildLeading(BuildContext context) {
+    return IconButton(
+      icon: const Icon(Icons.arrow_back),
+      onPressed: () => close(context, null),
+    );
+  }
+
+  @override
+  Widget buildSuggestions(BuildContext context) {
+    final filteredArticles = _filter(query);
+
+    if (query.isEmpty) {
+      return const Center(
+        child: Text('Start typing to search through the articles.'),
+      );
+    }
+
+    if (filteredArticles.isEmpty) {
+      return const Center(child: Text('No results found.'));
+    }
+
+    return ListView.builder(
+      itemCount: filteredArticles.length,
+      itemBuilder: (context, index) {
+        final article = filteredArticles.elementAt(index);
+        return ListTile(
+          title: Text(article.title),
+          subtitle: Text(article.description),
+          onTap: () => close(context, article),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget buildResults(BuildContext context) {
+    final filteredArticles = _filter(query);
+
+    if (filteredArticles.isEmpty) {
+      return const Center(child: Text('No results found.'));
+    }
+
+    return ListView.builder(
+      itemCount: filteredArticles.length,
+      itemBuilder: (context, index) {
+        final article = filteredArticles.elementAt(index);
+        return ListTile(
+          title: Text(article.title),
+          subtitle: Text(article.description),
+          onTap: () => close(context, article),
+        );
+      },
+    );
+  }
+
+  @override
+  List<Widget>? buildActions(BuildContext context) {
+    if (query.isEmpty) {
+      return null;
+    }
+
+    return [
+      IconButton(
+        icon: const Icon(Icons.clear),
+        onPressed: () {
+          query = '';
+          showSuggestions(context);
+        },
+      ),
+    ];
+  }
+}
+
+class ArticleDetailScreen extends StatelessWidget {
+  const ArticleDetailScreen({super.key, required this.article});
+
+  final Article article;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(article.title)),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: SingleChildScrollView(
+          child: Text(
+            article.content,
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,3 +18,4 @@ flutter:
   assets:
     - assets/images/
     - assets/sounds/
+    - assets/articles.json


### PR DESCRIPTION
## Summary
- replace the placeholder widget with a material article reader experience
- load articles from a JSON asset via an ArticleRepository instead of hardcoding them
- add search, loading, and error handling flows plus a scannable article detail screen

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd0353172c833299c2541c96f67439